### PR TITLE
Add cost IDs to completion report and contributions

### DIFF
--- a/payloads/CompletionReport.json
+++ b/payloads/CompletionReport.json
@@ -72,7 +72,7 @@
         "staffLinked": "Yes",
         "howCostsSpent": [
             {
-                
+                "projectCostId": "baa49446-cb70-46c7-ade1-0e17ad450c8a",
                 "costHeading": "free text",
                 "invoiceReference": "free text",
                 "invoiceDate": "2019-01-01",
@@ -81,6 +81,7 @@
                 "totalCostClaimed": 2000
             },
             {
+                "projectCostId": "baa49446-cb70-46c7-ade1-0e17ad450c8a",
                 "costHeading": "free text 2",
                 "invoiceReference": "free text",
                 "invoiceDate": "2019-01-01",

--- a/payloads/CompletionReport.json
+++ b/payloads/CompletionReport.json
@@ -72,6 +72,7 @@
         "staffLinked": "Yes",
         "howCostsSpent": [
             {
+                
                 "costHeading": "free text",
                 "invoiceReference": "free text",
                 "invoiceDate": "2019-01-01",

--- a/payloads/application.json
+++ b/payloads/application.json
@@ -81,22 +81,26 @@
             {
                 "description": "free text",
                 "secured": "yes-with-evidence",
-                "amount": 1000
+                "amount": 1000,
+                "id": "c4237718-ced7-4d03-a95b-1eceaecfdbe0"
             },
             {
                 "description": "free text",
                 "secured": "no",
-                "amount": 1000
+                "amount": 1000,
+                "id": "cf83a007-03e7-4940-a93b-135bb65e363e"
             },
             {
                 "description": "free text",
                 "secured": "not-sure",
-                "amount": 1000
+                "amount": 1000,
+                "id": "5b43682a-0c7d-4ded-ab11-2ad248497425"
             },
             {
                 "description": "free text",
                 "secured": "yes-no-evidence-yet",
-                "amount": 1000
+                "amount": 1000,
+                "id": "ec64bc3b-c580-419a-9eba-bbce6ffc0185"
             }
         ],
         "evidenceOfSupport": [

--- a/schemas/CompletionReport.schema.json
+++ b/schemas/CompletionReport.schema.json
@@ -353,6 +353,7 @@
               "type": ["object", "null"],
               "title": "The Items Schema",
               "required": [
+                "projectCostId",
                 "costHeading",
                 "invoiceReference",
                 "invoiceDate",
@@ -361,6 +362,14 @@
                 "totalCostClaimed"
               ],
               "properties": {
+                "projectCostId": {
+                  "$id": "#/properties/application/properties/howCostsSpent/items/properties/projectCostId",
+                  "type": "string",
+                  "title": "The projectCostId Schema",
+                  "description": "the associated project cost ID (UUID",
+                  "default": "",
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+                },
                 "costHeading": {
                   "$id": "#/properties/application/properties/howCostsSpent/items/properties/costHeading",
                   "type": "string",

--- a/schemas/CompletionReport.schema.json
+++ b/schemas/CompletionReport.schema.json
@@ -366,7 +366,7 @@
                   "$id": "#/properties/application/properties/howCostsSpent/items/properties/projectCostId",
                   "type": "string",
                   "title": "The projectCostId Schema",
-                  "description": "the associated project cost ID (UUID",
+                  "description": "the associated project cost ID (UUID)",
                   "default": "",
                   "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
                 },

--- a/schemas/application.schema.json
+++ b/schemas/application.schema.json
@@ -648,9 +648,20 @@
             "required": [
               "description",
               "secured",
-              "amount"
+              "amount",
+              "id"
             ],
             "properties": {
+              "id": {
+                "$id": "#/properties/application/properties/cashContributions/items/properties/id",
+                "type": "string",
+                "title": "cash contribution ID (UUID)",
+                "default": "",
+                "examples": [
+                  "c23e12e0-e69e-11e9-aaf2-2514879727cc"
+                ],
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+              },
               "description": {
                 "$id": "#/properties/application/properties/cashContributions/items/properties/description",
                 "type": "string",


### PR DESCRIPTION
This is part of https://trello.com/c/WpZOMqz0/930-generate-unique-id-for-each-project-cost-and-cash-contribution we need IDs so cash contributions can be changed. In the completion report invoices should be assigned against a project cost.
