### PR TITLE
remove secured from non-cash-contribution

### DIFF
--- a/payloads/application.json
+++ b/payloads/application.json
@@ -70,13 +70,11 @@
         "nonCashContributions": [
             {
                 "description": "Free text",
-                "estimatedValue": 1000,
-                "secured": "yes-with-evidence"
+                "estimatedValue": 1000
             },
             {
                 "description": "More free text",
-                "estimatedValue": 2000,
-                "secured": "not-sure"
+                "estimatedValue": 2000
             }
         ],
         "cashContributions": [

--- a/schemas/application.schema.json
+++ b/schemas/application.schema.json
@@ -605,7 +605,6 @@
             "required": [
               "description",
               "estimatedValue",
-              "secured"
             ],
             "properties": {
               "description": {
@@ -626,22 +625,6 @@
                 "examples": [
                   1000
                 ]
-              },
-              "secured": {
-                "$id": "#/properties/application/properties/nonCashContributions/items/properties/secured",
-                "type": "string",
-                "title": "The Secured Schema",
-                "default": "",
-                "enum": [
-                  "yes-with-evidence",
-                  "yes-no-evidence-yet",
-                  "no",
-                  "not-sure"
-                ],
-                "examples": [
-                  "yes-with-evidence"
-                ],
-                "pattern": "^(.*)$"
               }
             }
           }


### PR DESCRIPTION
remove `secured` field which was erroneously included for non-cash contributions.