### PR TITLE
Added new isAlsoApplicant flag to legal signatories payload

### DIFF
--- a/payloads/application.json
+++ b/payloads/application.json
@@ -130,16 +130,19 @@
             "role": "trustee",
             "name": "Jane Doe",
             "phone": "07777 777777",
-            "email": "jane1@example.com"
+            "email": "jane1@example.com",
+            "isAlsoApplicant": "false"
         },
         "authorisedSignatoryTwoDetails": {
             "role": "trustee",
             "name": "Jane Doe",
             "phone": "07777 777777",
-            "email": "jane2@example.com"
+            "email": "Lizzie87@example.com",
+            "isAlsoApplicant": "true"
         },
         "mainContactEmail": "Lizzie87@example.com",
         "mainContactPhone": "0345 4 10 20 30",
+        "mainContactIsAlsoSignatory": "true",
         "informationNotPubliclyAvailableRequest": "more free text",
         "keepInformed": false,
         "involveInResearch": true,

--- a/payloads/application.json
+++ b/payloads/application.json
@@ -142,7 +142,6 @@
         },
         "mainContactEmail": "Lizzie87@example.com",
         "mainContactPhone": "0345 4 10 20 30",
-        "mainContactIsAlsoSignatory": "true",
         "informationNotPubliclyAvailableRequest": "more free text",
         "keepInformed": false,
         "involveInResearch": true,

--- a/schemas/application.schema.json
+++ b/schemas/application.schema.json
@@ -921,13 +921,17 @@
             },
             "email": {
               "type": "string"
+            },
+            "isAlsoApplicant": {
+              "type": "boolean"
             }
           },
           "required": [
             "role",
             "name",
             "phone",
-            "email"
+            "email",
+            "isAlsoApplicant"
           ]
         },
         "authorisedSignatoryTwoDetails": {
@@ -944,13 +948,17 @@
             },
             "email": {
               "type": "string"
+            },
+            "isAlsoApplicant": {
+              "type": "boolean"
             }
           },
           "required": [
             "role",
             "name",
             "phone",
-            "email"
+            "email",
+            "isAlsoApplicant"
           ]
         }
       }

--- a/src/buildPayload.ts
+++ b/src/buildPayload.ts
@@ -142,13 +142,15 @@ export function buildPayload(formType: string, applicationId: string, organisati
                         "role": "trustee",
                         "name": "Jane Doe",
                         "phone": "07777 777777",
-                        "email": "jane1@example.com"
+                        "email": "jane1@example.com",
+                        "isAlsoApplicant": false
                     },
                     "authorisedSignatoryTwoDetails": {
                         "role": "trustee",
                         "name": "Jane Doe",
                         "phone": "07777 777777",
-                        "email": "jane2@example.com"
+                        "email": "Lizzie87@example.com",
+                        "isAlsoApplicant": true
                     },
                     "mainContactEmail": "Lizzie87@example.com",
                     "mainContactPhone": "0345 4 10 20 30"

--- a/src/buildPayload.ts
+++ b/src/buildPayload.ts
@@ -39,6 +39,7 @@ export function buildPayload(formType: string, applicationId: string, organisati
                     "projectCommunity": "Even more free text",
                     "projectOrgBestPlace": "Even more and more free text",
                     "projectAvailable": "Even more more more text",
+                    "projectCapitalWork": true,
                     "projectOutcome1": "More and more and more free text",
                     "projectOutcome2": "More and more and more free text",
                     "projectOutcome2Checked": true,


### PR DESCRIPTION
This commit contains updates to the application payload to reflect logic changes that have been made in the Salesforce backend. This allows for the creation of only one Contact object where the email matches for both a user (mainContact) and a legal signatory.

Additionally, this commit adds the `projectCapitalWorks` field to the payload that is built within `buildPayload.ts`.  This not being present was causing local submissions to fail when hitting Salesforce. Adding it in fixes this error.