### PR TITLE
Removed character which was causing schema build failures

### DIFF
--- a/schemas/application.schema.json
+++ b/schemas/application.schema.json
@@ -598,7 +598,7 @@
             "title": "The Items Schema",
             "required": [
               "description",
-              "estimatedValue",
+              "estimatedValue"
             ],
             "properties": {
               "description": {


### PR DESCRIPTION
Spurious `,` was causing schema validation failures.